### PR TITLE
Support Secret Replication

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -168,6 +168,9 @@ resource "aws_secretsmanager_secret" "default" {
   kms_key_id  = aws_kms_key.default.key_id
   tags        = module.this.tags
   #policy      = # TODO
+  replica {
+    region = var.destination_region
+  }
 }
 
 resource "aws_secretsmanager_secret_rotation" "default" {

--- a/main.tf
+++ b/main.tf
@@ -168,8 +168,13 @@ resource "aws_secretsmanager_secret" "default" {
   kms_key_id  = aws_kms_key.default.key_id
   tags        = module.this.tags
   #policy      = # TODO
-  replica {
-    region = var.destination_region
+
+  dynamic "replica" {
+    for_each = var.replica_regions
+    content {
+      kms_key_id = replica.value.kms_key_id
+      region     = replica.value.region
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,10 @@ variable "subnets_lambda" {
   type        = list(any)
   description = "The subnets where the Lambda Function will be run"
 }
+variable "destination_region" {
+  type        = string
+  description = "The Destionation Region for Secret Manager"
+}
 
 variable "mysql_username" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -19,9 +19,14 @@ variable "subnets_lambda" {
   type        = list(any)
   description = "The subnets where the Lambda Function will be run"
 }
-variable "destination_region" {
-  type        = string
-  description = "The Destionation Region for Secret Manager"
+
+variable "replica_regions" {
+  type = list(object({
+    kms_key_id = string
+    region     = string
+  }))
+  description = "A list of objects containing the regions to which to replicate the secret. Each element in the list must be an object with `kms_key_id` and `region` keys. `kms_key_id` may be set to `null` to use the default AWS-managed KMS key."
+  default     = []
 }
 
 variable "mysql_username" {


### PR DESCRIPTION
`aws_secretsmanager_secret` now supports `replica`.  Allow for the module to also support it.